### PR TITLE
correct template pattern in elasticsearch template

### DIFF
--- a/etc/dockbeat.template.json
+++ b/etc/dockbeat.template.json
@@ -237,5 +237,5 @@
   "settings": {
     "index.refresh_interval": "5s"
   },
-  "template": "dockerbeat-*"
+  "template": "dockbeat-*"
 }


### PR DESCRIPTION
The elasticsearch template still says dockerbeat fixed to say dockbeat
