### PR TITLE
Added "filter" field to filter containers by name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /dockbeat
 /dockbeat.test
 *.pyc
+.vscode
 
 atlassian-ide-plugin.xml
 dockbeat.iml

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ Dockbeat configuration file is located at `etc/dockbeat.yml`. This default templ
     - ENV : `DOCKER_KEY_PATH`
     - Beats variable : `input.tls.key_path`
     - Default value : no default value
+  - Filter containers by name with REGEXP
+    - ENV: `FILTER_CONTAINERS`
+    - Dockbeat variable: `filter.containers`
+    - Default value: no default value
+  - Exclude containers by name with REGEXP
+    - ENV: `FILTER_EXCLUDE`
+    - Dockbeat variable: `filter.exclude`
+    - Default value: no default value
                                        
 When launching it inside a docker container, you can modify the environment variables using the `-e` flag :
 

--- a/beater/dockbeat.go
+++ b/beater/dockbeat.go
@@ -278,6 +278,8 @@ func (d *Dockbeat) RunOneTime(b *beat.Beat) error {
 				if found, _ := regexp.MatchString(d.filter.Exclude, containerName); d.filter.Exclude == "" || !found { // And exclude is empty or is not in exclude regexp
 					logp.Debug("dockbeat", "ContainerName %v not excluded. Sending data...", containerName)
 					d.exportContainerStats(container)
+				} else {
+					logp.Debug("dockbeat", "ContainerName %v Excluded!", containerName)
 				}
 			} else {
 				if found, _ := regexp.MatchString(d.filter.Containers, containerName); found { // If container name is in Container regexp

--- a/config/config.go
+++ b/config/config.go
@@ -22,9 +22,15 @@ type StatsConfig struct {
 	Cpu       *bool `config:"cpu"`
 }
 
+type FilterConfig struct {
+	Containers *string `config:"containers"`
+	Exclude    *string `config:"exclude"`
+}
+
 type DockbeatConfig struct {
-	Period *int64      `config:"period"`
-	Socket *string     `config:"socket"`
-	Tls    TlsConfig   `config:"tls"`
-	Stats  StatsConfig `config:"stats"`
+	Period *int64       `config:"period"`
+	Socket *string      `config:"socket"`
+	Tls    TlsConfig    `config:"tls"`
+	Stats  StatsConfig  `config:"stats"`
+	Filter FilterConfig `config:"filter"`
 }

--- a/dockbeat.yml
+++ b/dockbeat.yml
@@ -31,6 +31,16 @@ dockbeat:
     memory: true
     blkio: true
     cpu: true
+
+  # Read metrics from specific containers
+  #filter:
+    # Read only metrics of containers whose name matches this regex. 
+    # If field not initialized, include all containers
+    # (Regexp format -> without initial and end '/' character)
+    #containers: "sut\\d*_"
+    # Exclude containers whose name matches this regex
+    #exclude: "sut_3717"
+
 ###############################################################################
 ############################# Libbeat Config ##################################
 # Base config file used by all other beats for using libbeat features


### PR DESCRIPTION
"filter" field has been added to filter containers by name with a regexp. There are two sub-fields:

- containers:
   - If this field is not set, metrics of All containers are sent.
   - If this field has a regexp, only the metrics of the containers whose names match the regexp are sent.
- exclude:
   - If this field is not set, no containers are excluded
   - If this field has a regexp, the containers whose names match the regexp are excluded.

Both fields can be combined to filter containers. For example, you can send metrics of all containers whose names starts with "example_" but exclude the container with name "example_2"